### PR TITLE
Deploy to Production

### DIFF
--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -27,6 +27,7 @@ clean-targets:         # directories to be removed by `dbt clean`
 
 seeds:
   dbt_training:
+    +schema: staging
     sale_dates:
       +column_types:
         SALE_DATE: date
@@ -38,12 +39,13 @@ vars:
 
 models:
   dbt_training:
-    # Config indicated by + and applies to all files under models/example/
     staging:
       +materialized: view
+      +schema: staging
     intermediate:
       +materialized: ephemeral
     marts:
       +materialized: table
+      +schema: marts
       +tags:
         - p1

--- a/macros/get_custom_schema.sql
+++ b/macros/get_custom_schema.sql
@@ -1,0 +1,3 @@
+{% macro generate_schema_name(custom_schema_name, node) -%}
+    {{ generate_schema_name_for_env(custom_schema_name, node) }}
+{%- endmacro %}


### PR DESCRIPTION
### Summary
Deploy current project to Production

### Details
Add `prod` target to `sample-profiles.yml`
`get_custom_schema.sql` - Uses the built-in macros `generate_schema_name` and `generate_schema_name_for_env`
   * Will result in all models being deployed to a `target` schema in non-prod environments (ex. `dev`, `qa`)
   * If `target` =  `prod` all models will be deployed to the individual custom schemas (ex. `staging`, `mart`)

Confirmed ability to deploy to `prod`.

### Checks
- [x] Follows style guide
- [x] Tested changes

### References
[Target](https://docs.getdbt.com/reference/dbt-jinja-functions/target)
[Using Custom Schemas](https://docs.getdbt.com/docs/building-a-dbt-project/building-models/using-custom-schemas)

